### PR TITLE
:only_reader => true/false option

### DIFF
--- a/lib/money/rails.rb
+++ b/lib/money/rails.rb
@@ -33,11 +33,11 @@ module ActiveRecord #:nodoc:
                 send "#{name}_without_cleanup=", amount.blank? ? nil : amount.to_money(options[:precision])
               end
               alias_method_chain "#{name}=", :cleanup
+          else
+            define_method name.to_s do
+              ::Money.new(send(options[:cents])).to_money(options[:precision])
+            end
           end
-          
-          define_method name.to_s do
-            ::Money.new(send(options[:cents])).to_money(options[:precision])
-          end if options[:only_reader]
         end
       end
     end


### PR DESCRIPTION
If the _cents attribute is a virtual (i.e. has only reader, not writer), composed_of fails. This adds a little switch to skip the composed_of and to create reader methods to fetch the money value of virtual attribute.
