### PR TITLE
Fix #9 String#to_money in Ruby 1.9

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -35,11 +35,11 @@ class String
   #
   def to_money(precision = nil)
     # Get the currency
-    matches = scan /([A-Z]{2,3})/ 
+    matches = scan /([A-Z]{2,3})/
     currency = matches[0] ? matches[0][0] : Money.default_currency
-    
+
     if !precision
-      precision = scan(/\.(\d+)/).to_s.length
+      precision = scan(/\.(\d+)/).join.length
       precision = 2 if precision < 2
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
+require 'active_support/core_ext/class'
+
 $: << File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 
-require 'spec'
+# require 'spec'
 require 'money'


### PR DESCRIPTION
This fixes #9 and makes all tests pass in Ruby 1.9.

I have not tested this in Ruby 1.8 but I expect it should work there as well.
